### PR TITLE
fix: add per-user Garmin/MQTT toggle persistence in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The UI displays version and environment badge (dev/prod/local) in the sidebar fo
 | ------------- | --------------------------------------------------------------- |
 | **Dashboard** | Last reading, average BP metrics, user filter (All/User1/User2) |
 | **History**   | BP/pulse charts, filterable table, CSV export                   |
-| **Sync**      | Manual sync with step-by-step instructions                      |
+| **Sync**      | Manual sync, per-user Garmin/MQTT options, save settings        |
 | **Settings**  | Configuration, Bluetooth pairing, Garmin tokens, MQTT status    |
 
 ### Settings Page Features
@@ -117,9 +117,11 @@ The Web UI uses [Font Awesome 6](https://fontawesome.com/) icons for a clean, co
 The Sync page guides you through the synchronization process:
 
 1. Press **BT button** on OMRON device (Bluetooth icon blinks)
-2. Check the confirmation box
-3. Click **Start Sync** within 30 seconds
-4. View results and logs
+2. Configure per-user sync options (Garmin/MQTT enable/disable)
+3. Optionally click **Save Settings** to persist options to config
+4. Check the confirmation box
+5. Click **Start Sync** within 30 seconds
+6. View results and logs
 
 **Important:** OMRON stays in Bluetooth mode for only ~30 seconds after pressing the BT button.
 
@@ -179,9 +181,13 @@ users:
   - name: "User1"
     omron_slot: 1 # Slot in OMRON device (1 or 2)
     garmin_email: "user1@example.com"
+    garmin_enabled: true # Enable/disable Garmin upload
+    mqtt_enabled: true # Enable/disable MQTT publish
   - name: "User2"
     omron_slot: 2
     garmin_email: "user2@example.com"
+    garmin_enabled: true
+    mqtt_enabled: true
 
 garmin:
   tokens_path: "./data/tokens" # OAuth tokens stored per user

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -21,11 +21,15 @@ users:
   - name: "User1"
     omron_slot: 1                     # Slot in OMRON device (1 or 2)
     garmin_email: "user@example.com"  # Garmin Connect email
+    garmin_enabled: true              # Enable Garmin upload for this user
+    mqtt_enabled: true                # Enable MQTT publish for this user
 
   # Uncomment for second user
   # - name: "User2"
   #   omron_slot: 2
   #   garmin_email: "user2@example.com"
+  #   garmin_enabled: true
+  #   mqtt_enabled: true
 
 # ----------------------------------------------------------------------------
 # Garmin Connect Configuration

--- a/streamlit_app/pages/2_Sync.py
+++ b/streamlit_app/pages/2_Sync.py
@@ -99,6 +99,31 @@ def main() -> None:
             # Global flags based on per-user settings
             sync_garmin = any(sync_garmin_users.values())
             sync_mqtt = any(sync_mqtt_users.values())
+
+            # Save Settings button
+            if st.button("Save Settings", key="save_sync_settings", icon=":material/save:"):
+                # Load current config
+                config_path = project_root / "config" / "config.yaml"
+                if config_path.exists():
+                    with open(config_path) as f:
+                        config = yaml.safe_load(f) or {}
+
+                    # Update user settings
+                    for user in config.get("users", []):
+                        slot = user.get("omron_slot")
+                        if slot in sync_garmin_users:
+                            user["garmin_enabled"] = sync_garmin_users[slot]
+                        if slot in sync_mqtt_users:
+                            user["mqtt_enabled"] = sync_mqtt_users[slot]
+
+                    # Save config
+                    with open(config_path, "w") as f:
+                        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+                    st.success("Settings saved!")
+                else:
+                    st.error("Config file not found")
+
         else:
             # Fallback if no users configured
             st.warning("No users configured. Configure in Settings first.")


### PR DESCRIPTION
Add Save Settings button to Sync page allowing users to persist their Garmin upload and MQTT publish preferences to config.yaml. Each user can now have individual garmin_enabled and mqtt_enabled flags in their configuration.