### PR TITLE
fix(ci): prevent GitHub Actions command injection in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Docker image
-        run: docker build -f docker/Dockerfile -t omron-garmin-bridge:pr-${{ github.event.number }} .
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: docker build -f docker/Dockerfile -t "omron-garmin-bridge:pr-${PR_NUMBER}" .
 
       - name: Test Docker image
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
-          docker run --rm omron-garmin-bridge:pr-${{ github.event.number }} pdm run python -c "import src.main; print('Import OK')"
+          docker run --rm "omron-garmin-bridge:pr-${PR_NUMBER}" pdm run python -c "import src.main; print('Import OK')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
     needs: [lint, test]
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     outputs:
       released: ${{ steps.release.outputs.released }}
@@ -111,34 +110,39 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Check for skip-ci marker
+        id: skip_check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if echo "$COMMIT_MSG" | grep -q '\[skip ci\]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Semantic Release
         id: release
+        if: steps.skip_check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEXT_VERSION=$(semantic-release version --print 2>&1 | tail -1) || true
-          echo "Next version would be: $NEXT_VERSION"
-
           if semantic-release version 2>&1 | tee /tmp/sr-output.txt; then
             if grep -q "No release will be made" /tmp/sr-output.txt; then
-              echo "released=false" >> $GITHUB_OUTPUT
-              echo "No release needed"
+              echo "released=false" >> "$GITHUB_OUTPUT"
             else
               VERSION=$(semantic-release version --print-last-released 2>/dev/null || echo "")
               if [ -n "$VERSION" ]; then
-                echo "released=true" >> $GITHUB_OUTPUT
-                echo "version=$VERSION" >> $GITHUB_OUTPUT
-                echo "tag=v$VERSION" >> $GITHUB_OUTPUT
-                echo "Released version $VERSION"
+                echo "released=true" >> "$GITHUB_OUTPUT"
+                echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+                echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
                 semantic-release publish
               else
-                echo "released=false" >> $GITHUB_OUTPUT
-                echo "Could not determine released version"
+                echo "released=false" >> "$GITHUB_OUTPUT"
               fi
             fi
           else
-            echo "released=false" >> $GITHUB_OUTPUT
-            echo "semantic-release version failed"
+            echo "released=false" >> "$GITHUB_OUTPUT"
           fi
 
   docker:


### PR DESCRIPTION
Move ${{ github.event.number }} from inline run: to env: block in CI,
and replace ${{ github.event.head_commit.message }} in if: expression
with a dedicated step using env: variable in release workflow.