### PR TITLE
ci: add PR labeling infrastructure

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,35 @@
+---
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**/*"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: "*.md"
+  - changed-files:
+      - any-glob-to-any-file: "docs/**/*"
+
+ble:
+  - changed-files:
+      - any-glob-to-any-file: "src/omron_ble/**/*"
+
+garmin:
+  - changed-files:
+      - any-glob-to-any-file: "src/garmin_uploader.py"
+
+mqtt:
+  - changed-files:
+      - any-glob-to-any-file: "src/mqtt_publisher.py"
+
+streamlit:
+  - changed-files:
+      - any-glob-to-any-file: "streamlit_app/**/*"
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file: "docker/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "Dockerfile"
+
+feature:
+  - head-branch: ['^feature', 'feature']

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,80 @@
+---
+# Area
+- name: ci
+  color: "9ac2f2"
+  description: Changes to CI/CD configuration
+
+- name: documentation
+  color: "F4D1B7"
+  description: Documentation changes
+
+- name: ble
+  color: "0075CA"
+  description: Bluetooth LE / OMRON device changes
+
+- name: garmin
+  color: "7057FF"
+  description: Garmin Connect integration changes
+
+- name: mqtt
+  color: "E4E669"
+  description: MQTT publisher changes
+
+- name: streamlit
+  color: "D876E3"
+  description: Streamlit Web UI changes
+
+- name: docker
+  color: "2496ED"
+  description: Docker/deployment changes
+
+# Size
+- name: size/S
+  color: "dc8add"
+  description: "PR changes 0-49 lines"
+
+- name: size/M
+  color: "c061cb"
+  description: "PR changes 50-199 lines"
+
+- name: size/L
+  color: "9141ac"
+  description: "PR changes 200-799 lines"
+
+- name: size/XL
+  color: "813d9c"
+  description: "PR changes 800+ lines"
+
+# Type
+- name: feature
+  color: "009900"
+  description: New feature
+
+- name: fix
+  color: "B60205"
+  description: Bug fix
+
+- name: refactor
+  color: "84b6eb"
+  description: Code refactoring
+
+- name: do-not-merge
+  color: "ee0701"
+  description: PR is not ready to merge
+
+# CI Status
+- name: "lint:ok"
+  color: "0E8A16"
+  description: "CI: linting passed"
+
+- name: "lint:failed"
+  color: "D93F0B"
+  description: "CI: linting failed"
+
+- name: "tests:ok"
+  color: "0E8A16"
+  description: "CI: tests passed"
+
+- name: "tests:failed"
+  color: "D93F0B"
+  description: "CI: tests failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  label-size:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/label-size.yml
+
+  labeler:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/labeler.yml
+
+  label-sync:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/label-sync.yml
+
   build-test:
     name: Build Docker (PR validation)
     runs-on: ubuntu-latest

--- a/.github/workflows/label-size.yml
+++ b/.github/workflows/label-size.yml
@@ -1,0 +1,24 @@
+---
+name: Label Size
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  label-size:
+    name: Label Size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Size label
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          sizes: >
+            {
+            "0": "S",
+            "50": "M",
+            "200": "L",
+            "800": "XL"
+            }

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,25 @@
+---
+name: Labels Sync
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label-sync:
+    name: Labels Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync label definitions
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yaml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-other-labels: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+---
+name: Labeler
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  labeler:
+    name: Labeler
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Auto-label by file paths
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yaml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Add label definitions (`.github/labels.yaml`) — area (ble, garmin, mqtt, streamlit, docker, ci, documentation), size (S/M/L/XL), type (feature, fix, refactor), CI status
- Add auto-labeling rules (`.github/labeler.yaml`) — file-path and branch-name based
- Add 3 reusable workflows: `labeler.yml` (actions/labeler), `label-size.yml` (pascalgn/size-label-action), `label-sync.yml` (EndBug/label-sync)
- Integrate label jobs into `ci.yml` — run in parallel with lint/test on PRs

## Test plan
- [ ] Open a test PR touching `src/omron_ble/` — verify `ble` label is applied
- [ ] Check that size label (S/M/L/XL) is assigned based on diff size
- [ ] Run `label-sync` manually via workflow_dispatch — verify labels appear in repo settings
- [ ] Confirm lint/test/build jobs are unaffected (no `needs` dependency on label jobs)