### PR TITLE
ci: bump GitHub Actions versions and add dependencies label

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -31,5 +31,11 @@ docker:
   - changed-files:
       - any-glob-to-any-file: "Dockerfile"
 
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: "pdm.lock"
+  - changed-files:
+      - any-glob-to-any-file: "pyproject.toml"
+
 feature:
   - head-branch: ['^feature', 'feature']

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -28,6 +28,10 @@
   color: "2496ED"
   description: Docker/deployment changes
 
+- name: dependencies
+  color: "0366D6"
+  description: Dependency updates
+
 # Size
 - name: size/S
   color: "dc8add"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -75,7 +75,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -99,7 +99,7 @@ jobs:
             type=ref,event=branch,prefix=dev-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -127,7 +127,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build Docker image
         env:

--- a/.github/workflows/label-retroactive.yml
+++ b/.github/workflows/label-retroactive.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Label all PRs
         env:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync label definitions
         uses: EndBug/label-sync@v2

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Auto-label by file paths
         uses: actions/labeler@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -81,7 +81,7 @@ jobs:
       tag: ${{ steps.release.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -98,7 +98,7 @@ jobs:
           grep "^version" pyproject.toml
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -152,7 +152,7 @@ jobs:
     if: needs.release.outputs.released == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.tag }}
 
@@ -175,7 +175,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6
- Bump `actions/setup-python` v5 → v6
- Bump `docker/build-push-action` v5 → v6
- Add `dependencies` label and labeler rule for `pdm.lock` / `pyproject.toml` changes

## Affected workflows
- `ci.yml`, `release.yml`, `labeler.yml`, `label-sync.yml`, `label-retroactive.yml`
- `.github/labels.yaml`, `.github/labeler.yaml`

## Test plan
- [ ] CI pipeline passes (lint, test, build-test)
- [ ] Label workflows trigger correctly on PR
- [ ] `dependencies` label applied when `pdm.lock` or `pyproject.toml` changes